### PR TITLE
make PEP8 compliant & add Numba & add timing

### DIFF
--- a/lj_functions.py
+++ b/lj_functions.py
@@ -9,7 +9,7 @@ Questions:
 """
 import numpy as np
 from numpy.linalg import norm
-from lj_io import *
+from lj_io import save_xyzmatrix
 
 
 def V_LJ(mag_r, sp):
@@ -21,14 +21,14 @@ def V_LJ(mag_r, sp):
     """
     V_rc = 4 * sp.eps * ((sp.sigma / sp.rc) ** 12 - (sp.sigma / sp.rc) ** 6)
     return 4 * sp.eps * ((sp.sigma / mag_r) ** 12 - (sp.sigma / mag_r) ** 6) - \
-    V_rc if mag_r < sp.rc else 0.0
+        V_rc if mag_r < sp.rc else 0.0
 
 
 def force(r, sp):
     """r is a vector"""
     mag_dr = norm(r)
-    return 4 * sp.eps * (-12 * (sp.sigma / mag_dr) ** 12 + 6 * (sp.sigma / mag_dr) ** 6) * r / mag_dr **2 \
-           if mag_dr < sp.rc else np.zeros(3)
+    return 4 * sp.eps * (-12 * (sp.sigma / mag_dr) ** 12 + 6 * (sp.sigma / mag_dr) ** 6) * r / mag_dr**2 \
+        if mag_dr < sp.rc else np.zeros(3)
 
 
 def tot_PE(pos_list, sp):
@@ -81,7 +81,7 @@ def force_list(pos_list, sp):
             G_n = G - np.round(G)
             dr_n = np.dot(cell, G_n)
             force_mat[i, j] = force(dr_n, sp)
-    
+
     force_mat -= np.transpose(force_mat, (1, 0, 2))
     return np.sum(force_mat, axis=1)
 
@@ -96,7 +96,7 @@ def verlet_step(pos_list2, pos_list1, sp):
 
 
 def vel_verlet_step(pos_list, vel_list, sp):
-    """The velocity Verlet algorithm, 
+    """The velocity Verlet algorithm,
     returning position and velocity matrices"""
     F = force_list(pos_list, sp)
     pos_list2 = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -113,10 +113,10 @@ def integrate(pos_list, vel_list, sp):
     Save each thermo-multiple step into xyz_frames.
     Mass set to 1.0.
     """
-    N = pos_list.shape[0]
-    Nframes = int(sp.Nt // sp.thermo)
+    # N = pos_list.shape[0]
+    # Nframes = int(sp.Nt // sp.thermo)
     n_fr = 1
-    xyz_frames = np.zeros((N, 3, Nframes))
+    # xyz_frames = np.zeros((N, 3, Nframes))
     E = np.zeros(sp.Nt)
     T = np.zeros(sp.Nt)
 
@@ -132,13 +132,11 @@ def integrate(pos_list, vel_list, sp):
         E[i] = tot_KE(vel_list) + tot_PE(pos_list, sp)
         T[i] = temperature(vel_list)
         if i % sp.thermo == 0:
-#            xyz_frames[:, :, n_fr] = pos_list
+            # xyz_frames[:, :, n_fr] = pos_list
             if sp.dump:
                 fname = "Dump/dump_" + str(i*sp.thermo) + ".xyz"
                 save_xyzmatrix(fname, pos_list)
             print("Step: %i, Temperature: %f" % (i, T[i]))
             n_fr += 1
-#    return xyz_frames, E
+    # return xyz_frames, E
     return E
-
-

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -3,13 +3,14 @@
 Simulation of LJ clusters in a box w pbc
 
 Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>]
-                 [--thermo <th>] [--dump]
+                 [--thermo <th>] [--dump] [--numba]
 
 Options:
     --T <T>             Temperature [default: 1.0]
     --Nt <Nt>           Number of time steps [default: 100]
     --dt <dt>           Timestep [default: 0.002]
     --thermo <th>       Print output this many times [default: 10]
+    --numba             Use Numba versions of functions
 
 02/04/16
 """
@@ -46,7 +47,8 @@ if __name__ == "__main__":
         sys.exit()
 
     sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt,
-                thermo=thermo, seed=seed, dump=args["--dump"])  # system params
+                thermo=thermo, seed=seed, dump=args["--dump"],
+                use_numba=args["--numba"])  # system params
 
     print(" =========== \n LJ clusters \n ===========")
     print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i"

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -18,6 +18,7 @@ import os
 import sys
 from docopt import docopt
 from lj_functions import init_pos, init_vel, integrate
+from timing import print_timing
 
 
 class mydict(dict):
@@ -77,3 +78,4 @@ if __name__ == "__main__":
 #        for i in range(Nf):
 #            fname = "Dump/dump_" + str((i+1)*thermo) + ".xyz"
 #            save_xyzmatrix(fname, xyz_frames[:, :, i])
+    print_timing()

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -2,7 +2,7 @@
 """
 Simulation of LJ clusters in a box w pbc
 
-Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>] 
+Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>]
                  [--thermo <th>] [--dump]
 
 Options:
@@ -13,11 +13,10 @@ Options:
 
 02/04/16
 """
-import numpy as np
-import os, sys
+import os
+import sys
 from docopt import docopt
-from lj_functions import *
-from lj_io import *
+from lj_functions import init_pos, init_vel, integrate
 
 
 class mydict(dict):
@@ -36,7 +35,7 @@ if __name__ == "__main__":
     Nt = int(args["--Nt"])
     dt = float(args["--dt"])
     thermo = int(args["--thermo"])
-    
+
     eps = 1.0
     sigma = 1.0
     rc = 3.0
@@ -45,20 +44,18 @@ if __name__ == "__main__":
     if N == 0:
         print("No particles, aborting.")
         sys.exit()
-    
-    sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt, \
-                thermo=thermo, seed=seed, dump=args["--dump"]) # system params
+
+    sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt,
+                thermo=thermo, seed=seed, dump=args["--dump"])  # system params
 
     print(" =========== \n LJ clusters \n ===========")
-    print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i" \
+    print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i"
           % (N, T, Nt, dt, thermo))
-
 
     if args["--dump"]:
         dumpdir = "Dump"
         if not os.path.exists(dumpdir):
             os.makedirs(dumpdir)
- 
 
     # init system
     print("Initialising the system...")
@@ -78,8 +75,3 @@ if __name__ == "__main__":
 #        for i in range(Nf):
 #            fname = "Dump/dump_" + str((i+1)*thermo) + ".xyz"
 #            save_xyzmatrix(fname, xyz_frames[:, :, i])
-
-    
-
-
-

--- a/rdf_lj.py
+++ b/rdf_lj.py
@@ -14,7 +14,7 @@ Options:
 import numpy as np
 import glob
 from docopt import docopt
-from lj_io import *
+from lj_io import read_xyzmatrix
 
 
 def dmatrix_numpy(xyz):
@@ -53,14 +53,12 @@ if __name__ == "__main__":
     rdf[:, 0] = r
 
     for infile in infiles:
-#        A = np.loadtxt(infile)
+        # A = np.loadtxt(infile)
         A = read_xyzmatrix(infile)[:, 1:]
         dist_vec = dist_vec_naive(A, L)
         h, _ = np.histogram(dist_vec, bins=bins)
         rdf[:, 1] += h
-    
-    rdf[:, 1] *= 1./float(len(infiles)) * L**3/len(dist_vec) /(4*np.pi*r**2 * dr)
+
+    rdf[:, 1] *= 1./float(len(infiles)) * L**3/len(dist_vec) / (4*np.pi*r**2 * dr)
     np.savetxt("rdf.out", rdf)
     print("rdf saved into rdf.out")
-
-

--- a/timing.py
+++ b/timing.py
@@ -1,0 +1,98 @@
+import os
+from collections import defaultdict
+from contextlib import contextmanager
+from itertools import groupby, chain
+import time
+import re
+import sys
+from io import StringIO
+
+
+_dotiming = 'TIMING' in os.environ
+_timing = defaultdict(float)
+_timing_stack = []
+
+
+@contextmanager
+def timing(name):
+    if _dotiming:
+        label = '>'.join(_timing_stack + [name])
+        _timing[label]
+        _timing_stack.append(name)
+        tm = time.time()
+    try:
+        yield
+    finally:
+        if _dotiming:
+            _timing[label] += time.time()-tm
+            _timing_stack.pop(-1)
+
+
+def print_timing():
+    if _dotiming:
+        groups = [sorted(group, key=lambda x: x[0])
+                  for _, group
+                  in groupby(_timing.items(), lambda x: x[0].split('>')[0])]
+        groups.sort(key=lambda x: x[0][1], reverse=True)
+        table = Table(align=['<', '<'])
+        for group in groups:
+            for row in group:
+                table.add_row(re.sub(r'\w+>', 4*' ', row[0]),
+                              '{:.4f}'.format(row[1]))
+        print(table, file=sys.stderr)
+
+
+class TableException(Exception):
+    pass
+
+
+def alignize(s, align, width):
+    l = len(s)
+    if l < width:
+        if align == '<':
+            s = s + (width-l)*' '
+        elif align == '>':
+            s = (width-l)*' ' + s
+        elif align == '|':
+            s = (-(l-width)//2)*' ' + s + ((width-l)//2)*' '
+    return s
+
+
+class Table:
+    def __init__(self, **kwargs):
+        self.rows = []
+        self.set_format(**kwargs)
+
+    def add_row(self, *row, free=False):
+        self.rows.append((free, row))
+
+    def set_format(self, sep=' ', align='>', indent=''):
+        self.sep = sep
+        self.align = align
+        self.indent = indent
+
+    def sort(self, key=lambda x: x[0]):
+        self.rows.sort(key=lambda x: key(x[1]), reverse=True)
+
+    def __str__(self):
+        col_nums = [len(row) for free, row in self.rows if not free]
+        if len(set(col_nums)) != 1:
+            raise TableException('Unequal column lengths: {}'.format(col_nums))
+        col_nums = col_nums[0]
+        cell_widths = [[len(cell) for cell in row]
+                       for free, row in self.rows if not free]
+        col_widths = [max(col) for col in zip(*cell_widths)]
+        seps = (col_nums-1)*[self.sep] if not isinstance(self.sep, list) else self.sep
+        seps += ['\n']
+        aligns = col_nums*[self.align] if not isinstance(self.align, list) else self.align
+        f = StringIO()
+        for free, row in self.rows:
+            if free:
+                f.write('{}\n'.format(row[0]))
+            else:
+                cells = (alignize(cell, align, width)
+                         for cell, align, width
+                         in zip(row, aligns, col_widths))
+                f.write('{}{}'.format(self.indent,
+                                      ''.join(chain.from_iterable(zip(cells, seps)))))
+        return f.getvalue()[:-1]


### PR DESCRIPTION
By rewriting `tot_PE` in Numba (activated with `--numba`), the speed of `tot_PE` is increased 40 times (2 s to 0.05 s). Se below the timings at the end of the respective outputs.

```
🐟 16:32 her@air ~/va/Re/ljsim master env TIMING=1 time ./lj_sim.py 10 .04
 =========== 
 LJ clusters 
 ===========
Particles: 40 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
Initialising the system...
Number of trials: %i 2
Starting integration...
Step: 10, Temperature: 7.966275
Step: 20, Temperature: 7.965986
Step: 30, Temperature: 7.949444
Step: 40, Temperature: 7.935225
Step: 50, Temperature: 7.930134
Step: 60, Temperature: 7.927752
Step: 70, Temperature: 7.921645
Step: 80, Temperature: 7.918652
Step: 90, Temperature: 7.923024
tot_PE 2.0824
        8.74 real         8.07 user         0.20 sys
🐟 16:32 her@air ~/va/Re/ljsim master env TIMING=1 time ./lj_sim.py 10 .04 --numba
 =========== 
 LJ clusters 
 ===========
Particles: 40 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
Initialising the system...
Number of trials: %i 2
Starting integration...
Step: 10, Temperature: 7.966275
Step: 20, Temperature: 7.965986
Step: 30, Temperature: 7.949444
Step: 40, Temperature: 7.935225
Step: 50, Temperature: 7.930134
Step: 60, Temperature: 7.927752
Step: 70, Temperature: 7.921645
Step: 80, Temperature: 7.918652
Step: 90, Temperature: 7.923024
tot_PE 0.0562
        7.14 real         6.26 user         0.20 sys
```
