### PR TITLE
Convert force_list to numba

### DIFF
--- a/lj_sim.py
+++ b/lj_sim.py
@@ -18,7 +18,7 @@ import os
 import sys
 from docopt import docopt
 from lj_functions import init_pos, init_vel, integrate
-from timing import print_timing
+from timing import print_timing, timing
 
 
 class mydict(dict):
@@ -62,16 +62,18 @@ if __name__ == "__main__":
 
     # init system
     print("Initialising the system...")
-    pos_list, count, E = init_pos(N, sp)
+    with timing('init'):
+        pos_list, count, E = init_pos(N, sp)
+        vel_list = init_vel(N, T)
     print("Number of trials: %i", count)
-    vel_list = init_vel(N, T)
 
     # How to equilibrate?
 
     # run system
     print("Starting integration...")
 #    xyz_frames, E = integrate(pos_list, vel_list, sp)
-    E = integrate(pos_list, vel_list, sp)
+    with timing('integrate'):
+        E = integrate(pos_list, vel_list, sp)
 
     # print into file
 #    Nf = xyz_frames.shape[-1]


### PR DESCRIPTION
The speedup is 10-fold for the whole program run, but we're paying 1 s in startup time for the JIT compilation. On my computer, I can do 4.5 times more particles within the same time frame,

```
🐟 19:36 her@air ~/va/Re/ljsim master [143] env TIMING=1 time ./lj_sim.py 20 .04 --numba
 =========== 
 LJ clusters 
 ===========
Particles: 320 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
...
integrate      22.0249
    force_list 18.7954
    tot_PE     3.1867 
init           0.3238 
    tot_PE     0.3225 
       24.88 real        24.28 user         0.25 sys
🐟 19:37 her@air ~/va/Re/ljsim master env TIMING=1 time ./lj_sim.py 12 .04
 =========== 
 LJ clusters 
 ===========
Particles: 69 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
...
integrate      22.7221
    force_list 16.0197
    tot_PE     6.6704 
init           0.1920 
    tot_PE     0.1917 
       25.66 real        24.52 user         0.30 sys
```
