### PR TITLE
add Fortran versions of functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ __pycache__
 *.out
 /*.c
 *.so
+*.so.dSYM
+*.mod
 Dump/
 /build
+/system.mk

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,22 @@
-all:
+include system.mk
+blddir = build
+FFLAGS = -Og -fcheck=all
+F2PY ?= f2py
+
+all: lj_functions_c lj_functions_f
+
+lj_functions_c:
 	python3 setup.py build_ext --inplace
+
+lj_functions_f:
+	@mkdir -p ${blddir}
+	CFLAGS="${CFLAGS}" ${F2PY} -c --build-dir ${blddir} --fcompiler=${FVENDOR} \
+		   --f90exec=${FC} --f90flags="${FFLAGS}" --compiler=${CVENDOR} \
+		   -m $@ ${LDFLAGS} lj_functions_f.f90
+
+clean:
+	-rm *.mod
+	-rm -r build
+
+distclean: clean
+	-rm *.so

--- a/example.system.mk
+++ b/example.system.mk
@@ -1,0 +1,4 @@
+FVENDOR = gnu95
+CVENDOR = unix
+FC = mpifort
+LDFLAGS = -llapack

--- a/lj_functions.py
+++ b/lj_functions.py
@@ -13,6 +13,7 @@ from lj_io import save_xyzmatrix
 from numba import jit, float64
 from timing import timing
 import lj_functions_c as ljc
+from lj_functions_f import ljf
 
 
 def V_LJ(mag_r, sp):
@@ -95,6 +96,8 @@ def init_pos(N, sp):
                 E = tot_PE_numba(pos_list, sp.eps, sp.sigma, sp.rc)
             elif sp.use_cython:
                 E = ljc.tot_PE(pos_list, sp)
+            elif sp.use_fortran:
+                E = ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
             else:
                 E = tot_PE(pos_list, sp)
         count += 1
@@ -166,6 +169,8 @@ def vel_verlet_step(pos_list, vel_list, sp):
             F = force_list_numba(pos_list, sp.L, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             F = ljc.force_list(pos_list, sp)
+        elif sp.use_fortran:
+            F = ljf.force_list(pos_list, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
         else:
             F = force_list(pos_list, sp)
     pos_list2 = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -174,6 +179,8 @@ def vel_verlet_step(pos_list, vel_list, sp):
             F2 = force_list_numba(pos_list2, sp.L, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             F2 = ljc.force_list(pos_list2, sp)
+        elif sp.use_fortran:
+            F2 = ljf.force_list(pos_list2, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
         else:
             F2 = force_list(pos_list2, sp)
     vel_list2 = vel_list + (F + F2) * sp.dt / 2
@@ -201,6 +208,8 @@ def integrate(pos_list, vel_list, sp):
             F = force_list_numba(pos_list, sp.L, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             F = ljc.force_list(pos_list, sp)
+        elif sp.use_fortran:
+            F = ljf.force_list(pos_list, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
         else:
             F = force_list(pos_list, sp)
     pos_list = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -209,6 +218,8 @@ def integrate(pos_list, vel_list, sp):
             E[0] = tot_KE(vel_list) + tot_PE_numba(pos_list, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             E[0] = tot_KE(vel_list) + ljc.tot_PE(pos_list, sp)
+        elif sp.use_fortran:
+            E[0] = tot_KE(vel_list) + ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
         else:
             E[0] = tot_KE(vel_list) + tot_PE(pos_list, sp)
     T[0] = temperature(vel_list)
@@ -221,6 +232,8 @@ def integrate(pos_list, vel_list, sp):
                 E[i] = tot_KE(vel_list) + tot_PE_numba(pos_list, sp.eps, sp.sigma, sp.rc)
             elif sp.use_cython:
                 E[i] = tot_KE(vel_list) + ljc.tot_PE(pos_list, sp)
+            elif sp.use_fortran:
+                E[i] = tot_KE(vel_list) + ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
             else:
                 E[i] = tot_KE(vel_list) + tot_PE(pos_list, sp)
         T[i] = temperature(vel_list)

--- a/lj_functions_c.pyx
+++ b/lj_functions_c.pyx
@@ -17,6 +17,7 @@ cdef struct Sp:
     bint dump
     bint use_numba
     bint use_cython
+    bint use_fortran
 
 
 @cython.boundscheck(False)

--- a/lj_functions_f.f90
+++ b/lj_functions_f.f90
@@ -1,0 +1,90 @@
+module ljf
+
+implicit none
+
+contains
+
+real(8) function norm(v)
+    real(8), intent(in) :: v(3)
+
+    norm = sqrt(sum(v**2))
+end function
+
+real(8) function V_LJ(mag_r, eps, sigma, rc)
+    real(8), intent(in) :: mag_r, eps, sigma, rc
+
+    real(8) :: V_rc
+
+    V_rc = 4*eps*((sigma/rc)**12 - (sigma/rc)**6)
+    if (mag_r < rc) then
+        V_LJ = 4*eps*((sigma/mag_r)**12 - (sigma/mag_r)**6) - V_rc
+    else
+        V_LJ = 0.d0
+    end if
+end function
+
+function force(r, eps, sigma, rc)
+    real(8), intent(in) :: r(3), eps, sigma, rc
+    real(8) :: force(3)
+
+    real(8) :: mag_dr
+
+    mag_dr = norm(r)
+    if (mag_dr < rc) then
+        force = 4*eps*(-12*(sigma/mag_dr)**12 + 6*(sigma/mag_dr)**6)*r/mag_dr**2
+    else
+        force = 0.d0
+    end if
+end function
+
+real(8) function tot_PE(pos_list, eps, sigma, rc) result(E)
+    real(8), intent(in) :: pos_list(:, :), eps, sigma, rc
+
+    integer :: N, i, j
+
+    E = 0.d0
+    N = size(pos_list, 1)
+    do i = 1, N
+        do j = i+1, N
+            E = E + V_LJ(norm(pos_list(i, :)-pos_list(j, :)), eps, sigma, rc)
+        end do
+    end do
+end function
+
+function force_list(pos_list, L, eps, sigma, rc, inv) result(F)
+    real(8), intent(in) :: pos_list(:, :), L, eps, sigma, rc
+    real(8) :: F(size(pos_list, 1), 3)
+    external :: inv
+    interface
+        subroutine inv(A, n, A_inv)
+            integer :: n
+            real(8), intent(in) :: A(n, n)
+            real(8), intent(out) :: A_inv(n, n)
+        end subroutine
+    end interface
+
+    real(8) :: &
+        force_mat(size(pos_list, 1), size(pos_list, 1), 3), &
+        cell(3, 3), inv_cell(3, 3), dr(3), G(3), G_n(3), dr_n(3)
+    integer :: N, i, j
+
+    N = size(pos_list, 1)
+    force_mat(:, :, :) = 0.d0
+    cell(:, :) = 0.d0
+    forall (i = 1:3) cell(i, i) = 1.d0
+    cell = L*cell
+    call inv(cell, 3, inv_cell)
+    do i = 1, N
+        do j = 1, i-1
+            dr = pos_list(j, :)-pos_list(i, :)
+            G = matmul(inv_cell, dr)
+            G_n = G-nint(G)
+            dr_n = matmul(cell, G_n)
+            force_mat(i, j, :) = force(dr_n, eps, sigma, rc)
+        end do
+    end do
+    force_mat = force_mat - reshape(force_mat, [N, N, 3], order=[2, 1, 3])
+    F = sum(force_mat, 2)
+end function
+
+end module

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -3,7 +3,7 @@
 Simulation of LJ clusters in a box w pbc
 
 Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>]
-                 [--thermo <th>] [--dump] [--numba | --cython]
+                 [--thermo <th>] [--dump] [--numba | --cython | --fortran]
 
 Options:
     --T <T>             Temperature [default: 1.0]
@@ -11,7 +11,8 @@ Options:
     --dt <dt>           Timestep [default: 0.002]
     --thermo <th>       Print output this many times [default: 10]
     --numba             Use Numba versions of functions
-    --cython            Use Cyton versions of functions
+    --cython            Use Cython versions of functions
+    --fortran           Use Fortran versions of functions
 
 02/04/16
 """
@@ -50,7 +51,8 @@ if __name__ == "__main__":
 
     sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt,
                 thermo=thermo, seed=seed, dump=args["--dump"],
-                use_numba=args["--numba"], use_cython=args['--cython'])  # system params
+                use_numba=args["--numba"], use_cython=args['--cython'],
+                use_fortran=args['--fortran'])  # system params
 
     print(" =========== \n LJ clusters \n ===========")
     print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i"


### PR DESCRIPTION
And here goes fortran. ~Same speed as Cython.

Adapt `example.system.mk` before `make`.

```
🐟 12:51 her@air ~/va/Re/ljsim fortran env TIMING=1 NUMBA_DISABLE_JIT=1 time ./lj_sim.py 12 .04 --cython
integrate      0.2431
    force_list 0.1961
    tot_PE     0.0134
init           0.0006
    tot_PE     0.0003
        0.72 real         0.62 user         0.07 sys
🐟 12:51 her@air ~/va/Re/ljsim fortran env TIMING=1 NUMBA_DISABLE_JIT=1 time ./lj_sim.py 12 .04 --fortran
integrate      0.1618
    force_list 0.1065
    tot_PE     0.0300
init           0.0024
    tot_PE     0.0021
        0.65 real         0.54 user         0.07 sys
```
