### PR TITLE
Add C-binded Fortran versions of lj_functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ __pycache__
 *.out
 /*.c
 *.so
+*.so.dSYM
+*.mod
 Dump/
 /build
+/system.mk

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,22 @@
-all:
+include system.mk
+blddir = build
+FFLAGS = -Og -fcheck=all
+F2PY ?= f2py
+
+all: lj_functions_c lj_functions_f
+
+lj_functions_c:
 	python3 setup.py build_ext --inplace
+
+lj_functions_f:
+	@mkdir -p ${blddir}
+	CFLAGS="${CFLAGS}" ${F2PY} -c --build-dir ${blddir} --fcompiler=${FVENDOR} \
+		   --f90exec=${FC} --f90flags="${FFLAGS}" --compiler=${CVENDOR} \
+		   -m $@ ${LDFLAGS} lj_functions_f.f90
+
+clean:
+	-rm *.mod
+	-rm -r build
+
+distclean: clean
+	-rm *.so

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include system.mk
 blddir = build
-FFLAGS = -Og -fcheck=all
+FFLAGS ?= -O3
 F2PY ?= f2py
 
 all: lj_functions_c lj_functions_f
@@ -12,11 +12,15 @@ lj_functions_f:
 	@mkdir -p ${blddir}
 	CFLAGS="${CFLAGS}" ${F2PY} -c --build-dir ${blddir} --fcompiler=${FVENDOR} \
 		   --f90exec=${FC} --f90flags="${FFLAGS}" --compiler=${CVENDOR} \
-		   -m $@ ${LDFLAGS} lj_functions_f.f90
+		   -m $@ ${LDFLAGS} $@.f90
 
 clean:
 	-rm *.mod
 	-rm -r build
+	-rm *.so
+	-rm -r *.so.dSYM
+	-rm *.c
+	-rm -r __pycache__
 
 distclean: clean
 	-rm *.so

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ blddir = build
 FFLAGS ?= -O3
 F2PY ?= f2py
 
-all: lj_functions_c lj_functions_f
+all: lj_functions_c lj_functions_f ljcf.so
+
+ljcf.so: ljcf.f90
+	${FC} -shared -fPIC ${FFLAGS} -o $@ $^
 
 lj_functions_c:
 	python3 setup.py build_ext --inplace

--- a/example.system.mk
+++ b/example.system.mk
@@ -1,4 +1,3 @@
 FVENDOR = gnu95
 CVENDOR = unix
-FC = mpifort
-LDFLAGS = -llapack
+FC = gfortran

--- a/example.system.mk
+++ b/example.system.mk
@@ -1,0 +1,4 @@
+FVENDOR = gnu95
+CVENDOR = unix
+FC = mpifort
+LDFLAGS = -llapack

--- a/lj_functions.py
+++ b/lj_functions.py
@@ -14,6 +14,7 @@ from numba import jit, float64
 from timing import timing
 import lj_functions_c as ljc
 from lj_functions_f import ljf
+import lj_functions_cf as ljcf
 
 
 def V_LJ(mag_r, sp):
@@ -108,6 +109,8 @@ def init_pos(N, sp):
                 E = ljc.tot_PE(pos_list, sp)
             elif sp.use_fortran:
                 E = ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
+            elif sp.use_cfortran:
+                E = ljcf.tot_PE(pos_list, sp)
             else:
                 E = tot_PE(pos_list, sp)
         count += 1
@@ -193,6 +196,8 @@ def vel_verlet_step(pos_list, vel_list, sp):
             F = ljc.force_list(pos_list, sp)
         elif sp.use_fortran:
             F = ljf.force_list(pos_list, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
+        elif sp.use_cfortran:
+            F = ljcf.force_list(pos_list, sp)
         else:
             F = force_list(pos_list, sp)
     pos_list2 = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -203,6 +208,8 @@ def vel_verlet_step(pos_list, vel_list, sp):
             F2 = ljc.force_list(pos_list2, sp)
         elif sp.use_fortran:
             F2 = ljf.force_list(pos_list2, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
+        elif sp.use_cfortran:
+            F2 = ljcf.force_list(pos_list2, sp)
         else:
             F2 = force_list(pos_list2, sp)
     vel_list2 = vel_list + (F + F2) * sp.dt / 2
@@ -232,6 +239,8 @@ def integrate(pos_list, vel_list, sp):
             F = ljc.force_list(pos_list, sp)
         elif sp.use_fortran:
             F = ljf.force_list(pos_list, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
+        elif sp.use_cfortran:
+            F = ljcf.force_list(pos_list, sp)
         else:
             F = force_list(pos_list, sp)
     pos_list = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -242,6 +251,8 @@ def integrate(pos_list, vel_list, sp):
             E[0] = tot_KE(vel_list) + ljc.tot_PE(pos_list, sp)
         elif sp.use_fortran:
             E[0] = tot_KE(vel_list) + ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
+        elif sp.use_cfortran:
+            E[0] = tot_KE(vel_list) + ljcf.tot_PE(pos_list, sp)
         else:
             E[0] = tot_KE(vel_list) + tot_PE(pos_list, sp)
     T[0] = temperature(vel_list)
@@ -256,6 +267,8 @@ def integrate(pos_list, vel_list, sp):
                 E[i] = tot_KE(vel_list) + ljc.tot_PE(pos_list, sp)
             elif sp.use_fortran:
                 E[i] = tot_KE(vel_list) + ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
+            elif sp.use_cfortran:
+                E[i] = tot_KE(vel_list) + ljcf.tot_PE(pos_list, sp)
             else:
                 E[i] = tot_KE(vel_list) + tot_PE(pos_list, sp)
         T[i] = temperature(vel_list)

--- a/lj_functions.py
+++ b/lj_functions.py
@@ -13,6 +13,7 @@ from lj_io import save_xyzmatrix
 from numba import jit, float64
 from timing import timing
 import lj_functions_c as ljc
+from lj_functions_f import ljf
 
 
 def V_LJ(mag_r, sp):
@@ -95,6 +96,8 @@ def init_pos(N, sp):
                 E = tot_PE_numba(pos_list, sp.eps, sp.sigma, sp.rc)
             elif sp.use_cython:
                 E = ljc.tot_PE(pos_list, sp)
+            elif sp.use_fortran:
+                E = ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
             else:
                 E = tot_PE(pos_list, sp)
         count += 1
@@ -166,6 +169,8 @@ def vel_verlet_step(pos_list, vel_list, sp):
             F = force_list_numba(pos_list, sp.L, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             F = ljc.force_list(pos_list, sp)
+        elif sp.use_fortran:
+            F = ljf.force_list(pos_list, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
         else:
             F = force_list(pos_list, sp)
     pos_list2 = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -174,6 +179,8 @@ def vel_verlet_step(pos_list, vel_list, sp):
             F2 = force_list_numba(pos_list2, sp.L, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             F2 = ljc.force_list(pos_list2, sp)
+        elif sp.use_fortran:
+            F2 = ljf.force_list(pos_list2, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
         else:
             F2 = force_list(pos_list2, sp)
     vel_list2 = vel_list + (F + F2) * sp.dt / 2
@@ -201,6 +208,8 @@ def integrate(pos_list, vel_list, sp):
             F = force_list_numba(pos_list, sp.L, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             F = ljc.force_list(pos_list, sp)
+        elif sp.use_fortran:
+            F = ljf.force_list(pos_list, sp.L, sp.eps, sp.sigma, sp.rc, np.linalg.inv)
         else:
             F = force_list(pos_list, sp)
     pos_list = pos_list + vel_list * sp.dt + F * sp.dt**2 / 2
@@ -209,6 +218,8 @@ def integrate(pos_list, vel_list, sp):
             E[0] = tot_KE(vel_list) + tot_PE_numba(pos_list, sp.eps, sp.sigma, sp.rc)
         elif sp.use_cython:
             E[0] = tot_KE(vel_list) + ljc.tot_PE(pos_list, sp)
+        elif sp.use_fortran:
+            E[0] = tot_KE(vel_list) + ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
         else:
             E[0] = tot_KE(vel_list) + tot_PE(pos_list, sp)
     T[0] = temperature(vel_list)
@@ -221,6 +232,8 @@ def integrate(pos_list, vel_list, sp):
                 E[i] = tot_KE(vel_list) + tot_PE_numba(pos_list, sp.eps, sp.sigma, sp.rc)
             elif sp.use_cython:
                 E[i] = tot_KE(vel_list) + ljc.tot_PE(pos_list, sp)
+            elif sp.use_fortran:
+                E[i] = tot_KE(vel_list) + ljf.tot_pe(pos_list, sp.eps, sp.sigma, sp.rc)
             else:
                 E[i] = tot_KE(vel_list) + tot_PE(pos_list, sp)
         T[i] = temperature(vel_list)

--- a/lj_functions_c.pyx
+++ b/lj_functions_c.pyx
@@ -18,6 +18,7 @@ cdef struct Sp:
     bint use_numba
     bint use_cython
     bint use_fortran
+    bint use_cfortran
 
 
 @cython.boundscheck(False)

--- a/lj_functions_c.pyx
+++ b/lj_functions_c.pyx
@@ -17,6 +17,7 @@ cdef struct Sp:
     bint dump
     bint use_numba
     bint use_cython
+    bint use_fortran
 
 
 @cython.boundscheck(False)

--- a/lj_functions_cf.py
+++ b/lj_functions_cf.py
@@ -1,0 +1,38 @@
+from ctypes import POINTER, CFUNCTYPE, c_double, c_int, c_bool, Structure, CDLL
+import numpy as np
+
+
+class Sp(Structure):
+    _fields_ = [(name, t) for t, names in [
+        (c_double, 'eps, sigma, rc, L, dt'),
+        (c_int, 'N, Nt, thermo, seed'),
+        (c_bool, 'dump, use_numba, use_cython, use_fortran, use_cfortran')
+    ] for name in names.split(', ')]
+
+
+Matrix = np.ctypeslib.ndpointer(dtype=np.float64, ndim=2, flags='F')
+MatrixFunc = CFUNCTYPE(None, POINTER(c_double), POINTER(c_double), c_int)
+
+
+@MatrixFunc
+def inv(A_in, A_out, n):
+    A_in = np.ctypeslib.as_array(A_in, (n, n))
+    A_out = np.ctypeslib.as_array(A_out, (n, n))
+    A_out[:] = np.linalg.inv(A_in)
+
+
+ljlib = CDLL('ljcf.so')
+ljlib.tot_pe.restype = c_double
+ljlib.tot_pe.argtypes = [Matrix, Sp, c_int]
+ljlib.force_list.restype = None
+ljlib.force_list.argtypes = [Matrix, Sp, MatrixFunc, Matrix, c_int]
+
+
+def tot_PE(pos_list, sp):
+    return ljlib.tot_pe(np.asfortranarray(pos_list), Sp(**sp), pos_list.shape[0])
+
+
+def force_list(pos_list, sp):
+    F = np.zeros_like(pos_list, order='F')
+    ljlib.force_list(np.asfortranarray(pos_list), Sp(**sp), inv, F, pos_list.shape[0])
+    return F

--- a/lj_functions_f.f90
+++ b/lj_functions_f.f90
@@ -1,0 +1,90 @@
+module ljf
+
+implicit none
+
+contains
+
+real(8) function norm(v)
+    real(8), intent(in) :: v(3)
+
+    norm = sqrt(sum(v**2))
+end function
+
+real(8) function V_LJ(mag_r, eps, sigma, rc)
+    real(8), intent(in) :: mag_r, eps, sigma, rc
+
+    real(8) :: V_rc
+
+    V_rc = 4*eps*((sigma/rc)**12 - (sigma/rc)**6)
+    if (mag_r < rc) then
+        V_LJ = 4*eps*((sigma/mag_r)**12 - (sigma/mag_r)**6) - V_rc
+    else
+        V_LJ = 0.d0
+    end if
+end function
+
+function force(r, eps, sigma, rc)
+    real(8), intent(in) :: r(3), eps, sigma, rc
+    real(8) :: force(3)
+
+    real(8) :: mag_dr
+
+    mag_dr = norm(r)
+    if (mag_dr < rc) then
+        force = 4*eps*(-12*(sigma/mag_dr)**12 + 6*(sigma/mag_dr)**6)*r/mag_dr**2
+    else
+        force = 0.d0
+    end if
+end function
+
+real(8) function tot_PE(pos_list, eps, sigma, rc) result(E)
+    real(8), intent(in) :: pos_list(:, :), eps, sigma, rc
+
+    integer :: N, i, j
+
+    E = 0.d0
+    N = size(pos_list, 1)
+    do i = 1, N
+        do j = i+1, N
+            E = E + V_LJ(norm(pos_list(i, :)-pos_list(j, :)), eps, sigma, rc)
+        end do
+    end do
+end function
+
+function force_list(pos_list, L, eps, sigma, rc, inv) result(F)
+    real(8), intent(in) :: pos_list(:, :), L, eps, sigma, rc
+    real(8) :: F(size(pos_list, 1), 3)
+    external :: inv
+    interface
+        subroutine inv(A, n, A_inv)
+            integer :: n
+            real(8), intent(in) :: A(n, n)
+            real(8), intent(out) :: A_inv(n, n)
+        end subroutine
+    end interface
+
+    real(8) :: &
+        force_mat(size(pos_list, 1), size(pos_list, 1), 3), &
+        cell(3, 3), inv_cell(3, 3), dr(3), G(3), G_n(3), dr_n(3)
+    integer :: N, i, j
+
+    N = size(pos_list, 1)
+    force_mat(:, :, :) = 0.d0
+    cell(:, :) = 0.d0
+    forall (i = 1:3) cell(i, i) = 1.d0
+    cell = L*cell
+    call inv(cell, 3, inv_cell)
+    do i = 1, N
+        do j = 1, i-1
+            dr = pos_list(j, :)-pos_list(i, :)
+            G = matmul(inv_cell, dr)
+            G_n = G-nint(G)
+            dr_n = matmul(cell, G_n)
+            force_mat(i, j, :) = force(dr_n, eps, sigma, rc)
+        end do
+    end do
+    force_mat = force_mat - reshape(force_mat, [N, N, 3], order=[2, 1, 3])
+    F = sum(force_mat, 2)
+end function
+
+end module

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -3,7 +3,7 @@
 Simulation of LJ clusters in a box w pbc
 
 Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>]
-                 [--thermo <th>] [--dump] [--numba | --cython]
+                 [--thermo <th>] [--dump] [--numba | --cython | --fortran]
 
 Options:
     --T <T>             Temperature [default: 1.0]
@@ -11,7 +11,8 @@ Options:
     --dt <dt>           Timestep [default: 0.002]
     --thermo <th>       Print output this many times [default: 10]
     --numba             Use Numba versions of functions
-    --cython            Use Cyton versions of functions
+    --cython            Use Cython versions of functions
+    --fortran           Use Fortran versions of functions
 
 02/04/16
 """
@@ -50,7 +51,8 @@ if __name__ == "__main__":
 
     sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt,
                 thermo=thermo, seed=seed, dump=args["--dump"],
-                use_numba=args["--numba"], use_cython=args['--cython'])  # system params
+                use_numba=args["--numba"], use_cython=args['--cython'],
+                use_fortran=args['--fortran'])  # system params
 
     print(" =========== \n LJ clusters \n ===========")
     print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i"

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -3,7 +3,8 @@
 Simulation of LJ clusters in a box w pbc
 
 Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>]
-                 [--thermo <th>] [--dump] [--numba | --cython | --fortran]
+                 [--thermo <th>] [--dump]
+                 [--numba | --cython | --fortran | --cfortran]
 
 Options:
     --T <T>             Temperature [default: 1.0]
@@ -13,6 +14,7 @@ Options:
     --numba             Use Numba versions of functions
     --cython            Use Cython versions of functions
     --fortran           Use Fortran versions of functions
+    --cfortran          Use C-binded Fortran versions of functions
 
 02/04/16
 """
@@ -49,10 +51,11 @@ if __name__ == "__main__":
         print("No particles, aborting.")
         sys.exit()
 
+    # system params
     sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt,
                 thermo=thermo, seed=seed, dump=args["--dump"],
                 use_numba=args["--numba"], use_cython=args['--cython'],
-                use_fortran=args['--fortran'])  # system params
+                use_fortran=args['--fortran'], use_cfortran=args['--cfortran'])
 
     print(" =========== \n LJ clusters \n ===========")
     print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i"

--- a/ljcf.f90
+++ b/ljcf.f90
@@ -1,0 +1,146 @@
+module lj_functions_cf
+
+use iso_c_binding
+
+implicit none
+
+private
+
+integer, parameter :: dp = c_double
+
+public :: tot_PE, force_list, c_tot_pe, c_force_list
+
+type, public, bind(c) :: Sp_t
+    real(dp) :: eps, sigma, rc, L, dt
+    integer :: N, Nt, thermo, seed
+    logical :: dump, use_numba, use_cython, use_fortran, use_cfortran
+end type
+
+abstract interface
+    subroutine matrix_op(A_in, A_out, n)
+        import :: dp
+        integer, intent(in), value :: n
+        real(dp), intent(in) :: A_in(n, n)
+        real(dp), intent(out) :: A_out(n, n)
+    end subroutine
+end interface
+
+contains
+
+real(dp) function norm(v)
+    real(dp), intent(in) :: v(3)
+
+    norm = sqrt(sum(v**2))
+end function
+
+real(dp) function V_LJ(mag_r, sp)
+    real(dp), intent(in) :: mag_r
+    type(Sp_t), intent(in) :: sp
+
+    real(dp) :: V_rc
+
+    V_rc = 4*sp%eps*((sp%sigma/sp%rc)**12 - (sp%sigma/sp%rc)**6)
+    if (mag_r < sp%rc) then
+        V_LJ = 4*sp%eps*((sp%sigma/mag_r)**12 - (sp%sigma/mag_r)**6) - V_rc
+    else
+        V_LJ = 0.d0
+    end if
+end function
+
+real(dp) function tot_PE(pos_list, sp) result(E)
+    real(dp), intent(in) :: pos_list(:, :)
+    type(Sp_t), intent(in) :: sp
+
+    integer :: N, i, j
+
+    E = 0.d0
+    N = size(pos_list, 1)
+    do i = 1, N
+        do j = i+1, N
+            E = E + V_LJ(norm(pos_list(i, :)-pos_list(j, :)), sp)
+        end do
+    end do
+end function
+
+real(dp) function c_tot_pe(pos_list, sp, n) result(E) bind(c, name='tot_pe')
+    integer, intent(in), value :: n
+    real(dp), intent(in) :: pos_list(n, 3)
+    type(Sp_t), intent(in), value :: sp
+
+    E = tot_PE(pos_list, sp)
+end function
+
+function force(r, sp)
+    real(dp), intent(in) :: r(3)
+    type(Sp_t), intent(in) :: sp
+    real(dp) :: force(3)
+
+    real(dp) :: mag_dr
+
+    mag_dr = norm(r)
+    if (mag_dr < sp%rc) then
+        force = 4*sp%eps*(-12*(sp%sigma/mag_dr)**12 + 6*(sp%sigma/mag_dr)**6)*r/mag_dr**2
+    else
+        force = 0.d0
+    end if
+end function
+
+function force_list(pos_list, sp, inv) result(F)
+    real(dp), intent(in) :: pos_list(:, :)
+    type(Sp_t), intent(in) :: sp
+    real(dp) :: F(size(pos_list, 1), 3)
+    interface
+        function inv(A)
+            import dp
+            real(dp), intent(in) :: A(:, :)
+            real(dp) :: inv(size(A, 2), size(A, 1))
+        end function
+    end interface
+
+    real(dp) :: &
+        force_mat(size(pos_list, 1), size(pos_list, 1), 3), &
+        cell(3, 3), inv_cell(3, 3), dr(3), G(3), G_n(3), dr_n(3)
+    integer :: N, i, j
+
+    N = size(pos_list, 1)
+    force_mat(:, :, :) = 0.d0
+    cell(:, :) = 0.d0
+    forall (i = 1:3) cell(i, i) = 1.d0
+    cell = sp%L*cell
+    inv_cell = inv(cell)
+    do i = 1, N
+        do j = 1, i-1
+            dr = pos_list(j, :)-pos_list(i, :)
+            G = matmul(inv_cell, dr)
+            G_n = G-nint(G)
+            dr_n = matmul(cell, G_n)
+            force_mat(i, j, :) = force(dr_n, sp)
+        end do
+    end do
+    force_mat = force_mat - reshape(force_mat, [N, N, 3], order=[2, 1, 3])
+    F = sum(force_mat, 2)
+end function
+
+subroutine c_force_list(pos_list, sp, c_inv, F, n) bind(c, name='force_list')
+    integer, intent(in), value :: n
+    real(dp), intent(in) :: pos_list(n, 3)
+    type(Sp_t), intent(in), value :: sp
+    real(dp), intent(out) :: F(n, 3)
+    type(c_funptr), value :: c_inv
+
+    procedure(matrix_op), pointer :: f_inv
+
+    call c_f_procpointer(c_inv, f_inv)
+    F = force_list(pos_list, sp, inv)
+
+    contains
+
+    function inv(A)
+        real(dp), intent(in) :: A(:, :)
+        real(dp) :: inv(size(A, 2), size(A, 1))
+
+        call f_inv(A, inv, size(A, 1))
+    end function
+end subroutine
+
+end module


### PR DESCRIPTION
This is as fast as f2py, but accepts the SP structure. My guess is that it's slower than Cython because we're calling the functions many times and there is an overhead associated with i) converting the arrays to Fortran byte order and ii) possibly some wrapping that Numpy does when converting to C pointers. Cython, on the other hand, uses the Python built-in [`memoryview`](https://docs.python.org/3.5/library/stdtypes.html?highlight=memoryview#binaryseq) which accesses the memory directly, probably with no wrapping at all.

```
🐟 21:50 her@air ~/va/Re/ljsim numba-opt env TIMING=1 time ./lj_sim.py 25 .04 --cython
integrate      7.5185
    force_list 7.2845
    tot_PE     0.1871
init           0.2481
    tot_PE     0.2375
       10.14 real         8.92 user         0.92 sys
🐟 21:51 her@air ~/va/Re/ljsim numba-opt env TIMING=1 time ./lj_sim.py 25 .04 --fortran
integrate      11.2854
    force_list 9.5500 
    tot_PE     1.6833 
init           2.6888 
    tot_PE     2.6719 
       16.16 real        14.85 user         0.92 sys
🐟 21:51 her@air ~/va/Re/ljsim numba-opt env TIMING=1 time ./lj_sim.py 25 .04 --cfortran
integrate      11.5472
    force_list 9.7980 
    tot_PE     1.6927 
init           2.1852 
    tot_PE     2.1714 
       16.30 real        14.86 user         1.03 sys
🐟 21:53 her@air ~/va/Re/ljsim c-fortran env TIMING=1 time ./lj_sim.py 25 .04 --numba
integrate      13.0998
    force_list 12.5752
    tot_PE     0.4755 
init           0.6381 
    tot_PE     0.6268 
       16.03 real        15.18 user         0.59 sys
```
